### PR TITLE
feat: optimizing the loading script so that icons can be loaded from …

### DIFF
--- a/packages/figma-fetcher/src/helpers.js
+++ b/packages/figma-fetcher/src/helpers.js
@@ -11,8 +11,8 @@ export function getConfig() {
   return {
     token: envConfig.FIGMA_FETCHER_FIGMA_TOKEN,
     fileKey: envConfig.FIGMA_FETCHER_FILE_KEY,
-    frameNames: envConfig.FIGMA_FETCHER_FRAME_NAMES,
-    pageNames: envConfig.FIGMA_FETCHER_PAGE_NAMES,
+    frameNames: envConfig.FIGMA_FETCHER_FRAME_NAMES?.split(',').map(name => name.trim()) || [],
+    pageNames: envConfig.FIGMA_FETCHER_PAGE_NAMES?.split(',').map(name => name.trim()) || [],
     className: envConfig.FIGMA_FETCHER_CLASS_NAME,
     systemColor: envConfig.FIGMA_FETCHER_SYSTEM_COLOR,
     removeFromName: ['style=', 'type=', 'status='],


### PR DESCRIPTION
## Fix support for large Figma files

### Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [x] Enhancement (improving an existing functionality like performance)

### Description

This PR fixes the "Request too large" error that occurs when fetching icons from large Figma files by implementing a two-step approach and fixing configuration parsing.

**Changes made:**

1. **Two-step Figma API approach** (`getFigmaIcons.js`):
   - First fetch file structure with `depth=1` to get page IDs
   - Then fetch only specific pages using `/files/${fileKey}/nodes` endpoint
   - This significantly reduces the request size and avoids the "Request too large" error

2. **Fixed configuration parsing** (`helpers.js`):
   - Fixed `pageNames` and `frameNames` to properly parse comma-separated strings into arrays
   - Added proper string splitting and trimming: `envConfig.FIGMA_FETCHER_PAGE_NAMES?.split(',').map(name => name.trim()) || []`

**Benefits:**
- ✅ Resolves "Request too large" error for large Figma files
- ✅ Significantly faster performance (structure: ~1.4s, pages: ~0.7s vs previous full file fetch)
- ✅ More reliable - only fetches needed data
- ✅ Better error handling and logging
- ✅ Supports multiple pages and frames correctly

**Testing:**
- Successfully tested with large Figma file containing 349 icons
- Verified proper page and frame filtering
- Confirmed no breaking changes to existing functionality

## Related issue

- Fixes the "Request too large" error when fetching icons from large Figma files
- Improves performance and reliability of the figma-fetcher

### 📸 Screenshots (if appropriate)

```
Fetching Figma file structure...
Finished fetching structure in 1.381s
Found 1 target pages: Icons
Fetching specific pages...
Finished fetching pages in 0.661s

Api returned 349 icons
```

### Checklist

- [x] I have linked an **issue** or **discussion**;
- [x] I have updated the **documentation** accordingly;
- [x] I have added or updated **tests** to cover my changes;
- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.